### PR TITLE
feat: add stargate-migrate command

### DIFF
--- a/cmd/fetchd/cmd/root.go
+++ b/cmd/fetchd/cmd/root.go
@@ -92,7 +92,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		genutilcli.InitCmd(app.ModuleBasics, app.DefaultNodeHome),
 		config.Cmd(),
 		genutilcli.CollectGenTxsCmd(banktypes.GenesisBalancesIterator{}, app.DefaultNodeHome),
-		genutilcli.MigrateGenesisCmd(),
+		AddStargateMigrateCmd(),
 		genutilcli.GenTxCmd(app.ModuleBasics, encodingConfig.TxConfig, banktypes.GenesisBalancesIterator{}, app.DefaultNodeHome),
 		genutilcli.ValidateGenesisCmd(app.ModuleBasics),
 		AddGenesisAccountCmd(app.DefaultNodeHome),

--- a/cmd/fetchd/cmd/stargatemigrate.go
+++ b/cmd/fetchd/cmd/stargatemigrate.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/CosmWasm/wasmd/x/wasm"
+	"github.com/spf13/cobra"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/client/flags"
+	"github.com/cosmos/cosmos-sdk/codec"
+	"github.com/cosmos/cosmos-sdk/crypto/keys/multisig"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/cosmos/cosmos-sdk/types/errors"
+	v038auth "github.com/cosmos/cosmos-sdk/x/auth/legacy/v038"
+	v039 "github.com/cosmos/cosmos-sdk/x/genutil/legacy/v039"
+	v040 "github.com/cosmos/cosmos-sdk/x/genutil/legacy/v040"
+	"github.com/cosmos/cosmos-sdk/x/genutil/types"
+	tmjson "github.com/tendermint/tendermint/libs/json"
+	tmtypes "github.com/tendermint/tendermint/types"
+)
+
+const flagGenesisTime = "genesis-time"
+const flagConsensusEvidenceMaxBytes = "consensus-evidence-max-bytes"
+
+// AddStargateMigrateCmd returns a command to migrate genesis to stargate version.
+func AddStargateMigrateCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "stargate-migrate [genesis-file]",
+		Short: "Migrate fetch.ai mainnet genesis to the stargate Cosmos SDK version",
+		Long: `Set the consensus.params.evidence.max_bytes value to 150Kb,
+removes multisig public keys that fail to decode, reset wasm module to its genesis state (as existing contracts are not backward compatible),
+and then migrate the given genesis to version v0.39, and then v0.40 of the cosmos-sdk.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			clientCtx := client.GetClientContextFromCmd(cmd)
+
+			importGenesis := args[0]
+			genDoc, err := tmtypes.GenesisDocFromFile(importGenesis)
+			if err != nil {
+				return fmt.Errorf("failed to load genesis file at %q: %w", importGenesis, err)
+			}
+
+			// Set consensus_params.evidence.max_bytes to avoid warning from 0 value
+			maxBytes, err := cmd.Flags().GetInt64(flagConsensusEvidenceMaxBytes)
+			if err != nil {
+				return fmt.Errorf("failed to retrieve flag %q: %w", flagConsensusEvidenceMaxBytes, err)
+			}
+			genDoc.ConsensusParams.Evidence.MaxBytes = maxBytes
+
+			var v038GenState types.AppMap
+			if err := json.Unmarshal(genDoc.AppState, &v038GenState); err != nil {
+				return errors.Wrap(err, "failed to JSON unmarshal initial genesis state")
+			}
+
+			v038Codec := codec.NewLegacyAmino()
+			v038auth.RegisterLegacyAminoCodec(v038Codec)
+
+			// Drop any multisig.LegacyAminoPubKey we have as v039 migration crash on them.
+			var authGenState v038auth.GenesisState
+			v038Codec.MustUnmarshalJSON(v038GenState[v038auth.ModuleName], &authGenState)
+			for i, acc := range authGenState.Accounts {
+				switch t := acc.(type) {
+				case *v038auth.BaseAccount:
+					switch t.PubKey.(type) {
+					case *multisig.LegacyAminoPubKey:
+						t.PubKey = nil
+						authGenState.Accounts[i] = t
+					default:
+						continue
+					}
+				default:
+					continue
+				}
+			}
+			v038GenState[v038auth.ModuleName] = v038Codec.MustMarshalJSON(authGenState)
+
+			// v039 migration
+			v039GenState := v039.Migrate(v038GenState, clientCtx)
+			// sanity check that the state can still be marhsalled to json
+			_, err = json.Marshal(v039GenState)
+			if err != nil {
+				return errors.Wrap(err, "failed to JSON marshal migrated genesis state")
+			}
+
+			// v040 migration
+			v040GenState := v040.Migrate(v039GenState, clientCtx)
+
+			// Reset wasm module to genesis
+			v040WasmDefaultState, err := json.Marshal(&wasm.GenesisState{
+				Params: wasm.DefaultParams(),
+			})
+			if err != nil {
+				return errors.Wrap(err, "failed to marshal wasm default genesis state")
+			}
+			v040GenState[wasm.ModuleName] = v040WasmDefaultState
+
+			// Update genesis with migrated state
+			genDoc.AppState, err = json.Marshal(v040GenState)
+			if err != nil {
+				return errors.Wrap(err, "failed to JSON marshal migrated genesis state")
+			}
+
+			genesisTime, err := cmd.Flags().GetString(flagGenesisTime)
+			if err != nil {
+				return fmt.Errorf("failed to read %q flag: %w", flagGenesisTime, err)
+			}
+			if genesisTime != "" {
+				var t time.Time
+
+				err := t.UnmarshalText([]byte(genesisTime))
+				if err != nil {
+					return errors.Wrap(err, "failed to unmarshal genesis time")
+				}
+
+				genDoc.GenesisTime = t
+			}
+
+			chainID, err := cmd.Flags().GetString(flags.FlagChainID)
+			if err != nil {
+				return fmt.Errorf("failed to read %q flag: %w", flags.FlagChainID, err)
+			}
+			if chainID != "" {
+				genDoc.ChainID = chainID
+			}
+
+			bz, err := tmjson.Marshal(genDoc)
+			if err != nil {
+				return errors.Wrap(err, "failed to marshal genesis doc")
+			}
+
+			sortedBz, err := sdk.SortJSON(bz)
+			if err != nil {
+				return errors.Wrap(err, "failed to sort JSON genesis doc")
+			}
+
+			fmt.Println(string(sortedBz))
+
+			return nil
+		},
+	}
+
+	cmd.Flags().String(flagGenesisTime, "", "override genesis_time with this flag")
+	cmd.Flags().Int64(flagConsensusEvidenceMaxBytes, 150000, "override consensus.evidence.max_bytes with this flag")
+	cmd.Flags().String(flags.FlagChainID, "", "override chain_id with this flag")
+
+	return cmd
+}

--- a/cmd/fetchd/cmd/stargatemigrate.go
+++ b/cmd/fetchd/cmd/stargatemigrate.go
@@ -24,13 +24,14 @@ import (
 
 const flagGenesisTime = "genesis-time"
 const flagConsensusEvidenceMaxBytes = "consensus-evidence-max-bytes"
+const flagInitialHeight = "initial-height"
 
 // AddStargateMigrateCmd returns a command to migrate genesis to stargate version.
 func AddStargateMigrateCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "stargate-migrate [genesis-file]",
-		Short: "Migrate fetch.ai mainnet genesis to the stargate Cosmos SDK version",
-		Long: `Set the consensus.params.evidence.max_bytes value to 150Kb,
+		Short: "Migrate fetchAI mainnet genesis to the stargate Cosmos SDK version",
+		Long: `Override the consensus.params.evidence.max_bytes value, set the new genesis_time, chain_id and initial_height,
 removes multisig public keys that fail to decode, reset wasm module to its genesis state (as existing contracts are not backward compatible),
 and then migrate the given genesis to version v0.39, and then v0.40 of the cosmos-sdk.`,
 		Args: cobra.ExactArgs(1),
@@ -49,6 +50,12 @@ and then migrate the given genesis to version v0.39, and then v0.40 of the cosmo
 				return fmt.Errorf("failed to retrieve flag %q: %w", flagConsensusEvidenceMaxBytes, err)
 			}
 			genDoc.ConsensusParams.Evidence.MaxBytes = maxBytes
+
+			initialHeight, err := cmd.Flags().GetInt64(flagInitialHeight)
+			if err != nil {
+				return fmt.Errorf("failed to retrieve flag %q: %w", flagInitialHeight, err)
+			}
+			genDoc.InitialHeight = initialHeight
 
 			var v038GenState types.AppMap
 			if err := json.Unmarshal(genDoc.AppState, &v038GenState); err != nil {
@@ -143,6 +150,7 @@ and then migrate the given genesis to version v0.39, and then v0.40 of the cosmo
 	}
 
 	cmd.Flags().String(flagGenesisTime, "", "override genesis_time with this flag")
+	cmd.Flags().Int64(flagInitialHeight, 0, "override initial_height with this flag")
 	cmd.Flags().Int64(flagConsensusEvidenceMaxBytes, 150000, "override consensus.evidence.max_bytes with this flag")
 	cmd.Flags().String(flags.FlagChainID, "", "override chain_id with this flag")
 

--- a/go.mod
+++ b/go.mod
@@ -18,4 +18,4 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-replace github.com/cosmos/cosmos-sdk => github.com/fetchai/cosmos-sdk v0.16.6-0.20210608070919-72b1457f05e7
+replace github.com/cosmos/cosmos-sdk => github.com/fetchai/cosmos-sdk v0.16.6-0.20210618154541-2685be5ca835

--- a/go.sum
+++ b/go.sum
@@ -159,8 +159,8 @@ github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+ne
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/fetchai/cosmos-sdk v0.16.6-0.20210608070919-72b1457f05e7 h1:QnqEAaNbf9LbkKKPVaVR8Mtq9UpjYaMrfigY3xZk6C8=
-github.com/fetchai/cosmos-sdk v0.16.6-0.20210608070919-72b1457f05e7/go.mod h1:3JyT+Ud7QRTO1/ikncNqVhaF526ZKNqh2HGMqXn+QHE=
+github.com/fetchai/cosmos-sdk v0.16.6-0.20210618154541-2685be5ca835 h1:I8KA+AthzhFZzE8XdsreC9GL62snAEhJz92ckmh5tfI=
+github.com/fetchai/cosmos-sdk v0.16.6-0.20210618154541-2685be5ca835/go.mod h1:3JyT+Ud7QRTO1/ikncNqVhaF526ZKNqh2HGMqXn+QHE=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=


### PR DESCRIPTION
This new command migrate a genesis file from current mainnet version
(sdk v0.38.3) to the stargate version (v0.42.5). Previous migration commands 
(provided by `x/genutils`) have been removed from the CLI to avoid confusion.

It handles:
- Setting default value for consensus.evidences.max_bytes which generate
  a warning if 0
- Removing multisig pubkeys if present, as they fail to decode properly
  with cosmos-sdk v0.38.3
- Resetting wasm module state, removing any existing contracts as they
  must be recompile for the newest VM version.
- Migrate genesis from v0.38 to v0.39, and then v0.39 to v0.40
- Allow override of genesis time and chain id