### PR TITLE
Add support for Swagger API documentation endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,8 @@ require (
 	github.com/spf13/cobra v1.1.3
 	github.com/tendermint/tendermint v0.34.11
 	github.com/tendermint/tm-db v0.6.4
+	github.com/rakyll/statik v0.1.7
+	github.com/gorilla/mux v1.8.0
 )
 
 // fix for "invalid Go type types.Dec for field ..." errors

--- a/go.mod
+++ b/go.mod
@@ -5,13 +5,13 @@ go 1.16
 require (
 	github.com/CosmWasm/wasmd v0.16.0
 	github.com/cosmos/cosmos-sdk v0.42.7
+	github.com/gorilla/mux v1.8.0
 	github.com/prometheus/client_golang v1.10.0
+	github.com/rakyll/statik v0.1.7
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.1.3
 	github.com/tendermint/tendermint v0.34.11
 	github.com/tendermint/tm-db v0.6.4
-	github.com/rakyll/statik v0.1.7
-	github.com/gorilla/mux v1.8.0
 )
 
 // fix for "invalid Go type types.Dec for field ..." errors


### PR DESCRIPTION
* The whole code has been copyied (exactly) from Cosmos-SDK `simapp/app.go`.