### PR TITLE
fix: keys add --recover fail when piped from file

### DIFF
--- a/cmd/fetchd/cmd/root.go
+++ b/cmd/fetchd/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"errors"
 	"io"
 	"math/big"
@@ -55,7 +56,7 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 		WithInterfaceRegistry(encodingConfig.InterfaceRegistry).
 		WithTxConfig(encodingConfig.TxConfig).
 		WithLegacyAmino(encodingConfig.Amino).
-		WithInput(os.Stdin).
+		WithInput(bufio.NewReader(os.Stdin)).
 		WithAccountRetriever(types.AccountRetriever{}).
 		WithBroadcastMode(flags.BroadcastBlock).
 		WithHomeDir(app.DefaultNodeHome).

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,6 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-replace github.com/cosmos/cosmos-sdk => github.com/fetchai/cosmos-sdk v0.17.3
+replace github.com/cosmos/cosmos-sdk => github.com/fetchai/cosmos-sdk v0.17.4
 
 replace github.com/tendermint/tendermint => github.com/fetchai/tendermint v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/facebookgo/subset v0.0.0-20150612182917-8dac2c3c4870/go.mod h1:5tD+ne
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/fetchai/cosmos-sdk v0.17.3 h1:QZ/ENCPtezmbe5ghroGOcuEQ8azmPgSr0AGAdzbwy14=
-github.com/fetchai/cosmos-sdk v0.17.3/go.mod h1:10aIThNwmk3ZVsTnXPGnHBLi9l60ctYk64+vsFrad6I=
+github.com/fetchai/cosmos-sdk v0.17.4 h1:KJADt3b9dqpOeeCUaxBiWzvzLX9ABeP05tS6037Xb/0=
+github.com/fetchai/cosmos-sdk v0.17.4/go.mod h1:10aIThNwmk3ZVsTnXPGnHBLi9l60ctYk64+vsFrad6I=
 github.com/fetchai/tendermint v1.0.0 h1:O88hdRfO1BZn0J5+ifcAGjIm89PGdZj6uSXMhzjsECc=
 github.com/fetchai/tendermint v1.0.0/go.mod h1:aeHL7alPh4uTBIJQ8mgFEE8VwJLXI1VD3rVOmH2Mcy0=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=


### PR DESCRIPTION
- Updated default CLI input to be a `*bufio.Reader` in order to allow reusing the same reader when reading from multiple places.
- Pull fix from cosmos-sdk v0.17.4