### PR TITLE
fix: better errors when bls validation fails

### DIFF
--- a/x/group/errors.go
+++ b/x/group/errors.go
@@ -13,4 +13,5 @@ var (
 	ErrUnauthorized = sdkerrors.Register(ModuleName, 207, "unauthorized")
 	ErrModified     = sdkerrors.Register(ModuleName, 208, "modified")
 	ErrExpired      = sdkerrors.Register(ModuleName, 209, "expired")
+	ErrBlsRequired  = sdkerrors.Register(ModuleName, 210, "bls required")
 )

--- a/x/group/server/msg_server.go
+++ b/x/group/server/msg_server.go
@@ -65,7 +65,7 @@ func (s serverImpl) CreateGroup(goCtx context.Context, req *group.MsgCreateGroup
 	if bls {
 		for _, mem := range members.Members {
 			if err := s.validateBlsMember(ctx, mem); err != nil {
-				return nil, sdkerrors.Wrapf(err, "member %s failed bls validation", mem.Address)
+				return nil, sdkerrors.Wrapf(group.ErrBlsRequired, "member %s failed bls validation: %v", mem.Address, err)
 			}
 		}
 	}
@@ -140,7 +140,7 @@ func (s serverImpl) UpdateGroupMembers(goCtx context.Context, req *group.MsgUpda
 		if g.BlsOnly {
 			for _, mem := range req.MemberUpdates {
 				if err := s.validateBlsMember(ctx, mem); err != nil {
-					return err
+					return sdkerrors.Wrapf(group.ErrBlsRequired, "member %s failed bls validation: %v", mem.Address, err)
 				}
 			}
 		}


### PR DESCRIPTION
when creating or updating groups and using the `--bls` flag to enforce members having bls keys, if one of the members doesn't have a bls key or haven't issued any transactions yet, the transaction currently report an obscure error like:
```
code: 1
codespace: undefined
data: ""
gas_used: "57634"
gas_wanted: "210000"
height: "2419"
info: ""
logs: []
raw_log: internal
```

This change makes it a bit easier to understand what's happening:

```
code: 210
codespace: group
data: ""
gas_used: "59306"
gas_wanted: "210000"
height: "124"
info: ""
logs: []
raw_log: 'failed to execute message; message index: 0: member fetch14s8xn6d4ku72p66n5862r2jr487xsyjxle3de8
  failed bls validation: account public key not set yet: bls required'
```
