### PR TITLE
docs: add link to faucet page

### DIFF
--- a/docs/docs/cli-tokens.md
+++ b/docs/docs/cli-tokens.md
@@ -22,6 +22,8 @@ pagination:
 
 ## Sending funds
 
+Before sending funds, make sure the sender address has tokens available by querying your balance as shown above. Checkout the [Token Faucet](../faucet/) page for more information on how to add test tokens to your address.
+
 To send funds from one address to another address then you would use the `tx send` subcommand. As shown below:
 
 ```bash


### PR DESCRIPTION
* Explained that sender address must have tokens available before sending funds.
* Added link to faucet page