### PR TITLE
fix: docker build

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -22,7 +22,7 @@ jobs:
           target: hub
 
       - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@v0
         with:
           service_account_key: ${{ secrets.GCLOUD_KEY_IMAGES }}
 


### PR DESCRIPTION
setup-gcloud action now refuse to execute without proper version
see: https://github.com/fetchai/fetchd/runs/5659056103?check_suite_focus=true
