### PR TITLE
docs: update fetchd versions doc

### DIFF
--- a/docs/docs/versions.md
+++ b/docs/docs/versions.md
@@ -2,12 +2,19 @@
 
 There are multiple versions of the fetchd software with differing levels of features and maturity. The following table outlines the rough overview of these versions
 
-| Version      | Maturity          | Description                                                                             |
-| ------------ | ----------------- | --------------------------------------------------------------------------------------- |
-| v0.2.x       | Stable            | This is a stable version of the network to support agent development                    |
-| v0.3.x       | Beta              | Builds upon our stable release and adds support for the random beacon consensus module  |
-| v0.4.x       | Alpha             | Builds upon the random beacon consensus and adds support for aggregated signatures      |
-| v0.5.x       | Release Candidate | Extension of v0.4.x                                                                     |
-| v0.6.x       | Release Candidate | Extension of v0.5.x                                                                     |
-| v0.7.x       | Stable            | Pre stargate fetchhub mainnet version                                                   |
-| v0.8.x       | Stable            | Mainline version of the network used for **Stargate** fetchhub mainnet                  |
+| Version      | Maturity   | Description                                                                             |
+| ------------ | ---------- | --------------------------------------------------------------------------------------- |
+| v0.2.x       | Deprecated | This is a stable version of the network to support agent development                    |
+| v0.3.x       | Deprecated | Builds upon our stable release and adds support for the random beacon consensus module  |
+| v0.4.x       | Deprecated | Builds upon the random beacon consensus and adds support for aggregated signatures      |
+| v0.5.x       | Deprecated | Extension of v0.4.x                                                                     |
+| v0.6.x       | Deprecated | Extension of v0.5.x                                                                     |
+| v0.7.x       | Deprecated | Pre stargate fetchhub mainnet version                                                   |
+| v0.8.x       | Deprecated | Mainline version of the network used for **Stargate** fetchhub mainnet                  |
+| v0.9.x       | Deprecated | Mainline version of the network used for **Carpicorn** fetchhub mainnet                 |
+| v0.10.x      | Stable     | Mainline version of the network used for **Dorado** fetchhub mainnet                    |
+
+
+# Upgrade history
+
+For node operators, the full upgrade history, documentations and procedures are available at: [https://github.com/fetchai/genesis-fetchhub](https://github.com/fetchai/genesis-fetchhub)


### PR DESCRIPTION
- add missing entries for fetchd v0.9.x and v0.10.x series
- add a link to genesis-fetchhub repo for upgrade and migration docs.
