### PR TITLE
docs: update dead links, index & README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,15 +7,6 @@ This repository contains the source code for validators on the Fetch network. Th
 ## Supported Systems
 
 The supported systems are limited by the dlls created in [`go-cosmwasm`](https://github.com/CosmWasm/go-cosmwasm). In particular, **we only support MacOS and Linux**.
-For linux, the default is to build for glibc, and we cross-compile with CentOS 7 to provide
-backwards compatibility for `glibc 2.12+`. This includes all known supported distributions
-using glibc (CentOS 7 uses 2.12, obsolete Debian Jessy uses 2.19).
-
-As of `0.5.x` we support `muslc` Linux systems, in particular **Alpine linux**,
-which is popular in docker distributions. Note that we do **not** store the
-static `muslc` build in the repo, so you must compile this yourself, and pass `-tags muslc`.
-Please look at the [`Dockerfile`](./Dockerfile) for an example of how we build a static Go
-binary for `muslc`. (Or just use this Dockerfile for your production setup).
 
 ## Quick Start
 
@@ -59,13 +50,7 @@ You can also verify that you are running the correct version
 fetchd version
 ```
 
-This should print a version number that must be compatible with the network you're connecting to (see the [network page](../networks/) for the list of supported versions per network).
-
-If instead you have an error: `Error: failed to parse log level (main:info,state:info,:error): Unknown Level String: 'main:info,state:info,:error', defaulting to NoLevel`, this means you had a pre-stargate version of fetchd (<= v0.7.x), and just installed a stargate version (>= v0.8.x), you'll need to remove the previous configuration files with:
-
-```bash
-rm ~/.fetchd/config/app.toml ~/.fetchd/config/config.toml
-```
+This should print a version number that must be compatible with the network you're connecting to (see the [network page](https://docs.fetch.ai/ledger_v2/live-networks/) for the list of supported versions per network).
 
 Alternatively, you can also build without installing the binary with:
 

--- a/docs/docs/building.md
+++ b/docs/docs/building.md
@@ -55,7 +55,7 @@ You can also verify that you are running the correct version
 fetchd version
 ```
 
-This should print a version number that must be compatible with the network you're connecting to (see the [network page](../networks/) for the list of supported versions per network).
+This should print a version number that must be compatible with the network you're connecting to (see the [network page](../live-networks/) for the list of supported versions per network).
 
 ## FAQ
 

--- a/docs/docs/cli-introduction.md
+++ b/docs/docs/cli-introduction.md
@@ -24,4 +24,4 @@ fetchd config chain-id dorado-1
 fetchd config node https://rpc-dorado.fetch.ai:443
 ```
 
-Checkout the [Network Information](../networks/) page for more detailed information on the available networks.
+Checkout the [Network Information](../live-networks/) page for more detailed information on the available networks.

--- a/docs/docs/faucet.md
+++ b/docs/docs/faucet.md
@@ -2,7 +2,7 @@
 
 For our test networks, we have a simple token faucet implemented to allow users of the network to get started quickly. You can send it an account address, and it will transfer some test token on it.
 
-Token Faucets are network specific, depending on the network type they may or may not be deployed. Please check the [networks](../networks/) page for specific details.
+Token Faucets are network specific, depending on the network type they may or may not be deployed. Please check the [networks](../live-networks/) page for specific details.
 
 The Token Faucet itself is available from the network block explorer (`GET FUNDS` button on the homepage).
 

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -1,25 +1,11 @@
 # Mainnet is here
 
-The fetchhub mainnet forms the core of the Fetch.ai ecosystem. In these pages, you will find all information to setup your client and connect on the [network](./networks/) and [cli-introduction](./cli-introduction/) pages. Previous test networks are still available as well for your tests and experiments.
+The fetchhub mainnet forms the core of the Fetch.ai ecosystem. In these pages, you will find all information to setup your client and connect on the [network](./live-networks/) and [cli-introduction](./cli-introduction/) pages.
 
-This documentation covers some of the things you need to know in order to prepare for and develop for this new network:
+This documentation covers some of the things you need to know in order to prepare for and develop on this network.
 
 ## Test Networks
 
-The starting point for most developers will be our Agent Land test network, since this is primarily used for agent development and testing. Agent Land is **fully supported** by our Agent Framework from version 0.6 and above. If you are developing autonomous economic agents using our latest framework, then moving to Agent Land is relatively straightforward, unless smart contracts are involved.
+The starting point for most will be [our test network](https://docs.fetch.ai/ledger_v2/live-networks/#test-nets), since it can provide you with test tokens with no value, that you can safely experiment with. 
 
-Agentland and other testnets on the journey have a new address format. Here is a typical example:
-
-```text
-fetch1almpjpf769p23k0v4m5eglvzr4jupsjs66vxf4
-```
-
-## Key links and information
-
-Block explorer and token tap: [https://explore-agent-land.fetch.ai/](https://explore-agent-land.fetch.ai/)
-
-For more detailed information, have a look at our [network](./networks/) information page.
-
-## Roadmap for Smart Contracts
-
-The fetchhub mainnet along with our test-nets support a webassembly (WASM) virtual machine VM. Smart contracts can be developed using Cosmwasm, which currently supports contracts written in Rust but will in future support a variety of languages such as  Go, Python or Javascript. For more information on Rust contracts for Cosmwasm, you can go to [https://www.cosmwasm.com/](https://www.cosmwasm.com/) and [https://github.com/CosmWasm/cosmwasm-template](https://github.com/CosmWasm/cosmwasm-template).
+Head over the [Command line client](https://docs.fetch.ai/ledger_v2/cli-introduction/) section for guidance on how to install and configure the `fetchd` client.

--- a/docs/docs/joining-a-testnet.md
+++ b/docs/docs/joining-a-testnet.md
@@ -10,7 +10,7 @@ Assuming that you have followed the [installation guide](../building/). You shou
 fetchd version
 ```
 
-This should print a version number that must be compatible with the network you're connecting to (see the [network page](../networks/) for the list of supported versions per network).
+This should print a version number that must be compatible with the network you're connecting to (see the [network page](../live-networks/) for the list of supported versions per network).
 
 ### Configuring the client fetchd
 

--- a/docs/docs/snapshots.md
+++ b/docs/docs/snapshots.md
@@ -3,7 +3,7 @@
 As blockchains get longer, the process of syncing from the genesis block begins to take many hours, or even days to complete.
 In circumstances where a faster sync is required, various snapshots of the fetchd chain state data are available for download, to more quickly bootstrap a node.
 
-Snapshots are available for both mainnet and the most recent testnet.  The URLs can be obtained from the [network page](../networks/).  
+Snapshots are available for both mainnet and the most recent testnet.  The URLs can be obtained from the [network page](../live-networks/).  
 We aim to update snapshots on a daily basis.
 
 The example below uses the pruned mainnet snapshot, but can be adapted as required for full or archive nodes.


### PR DESCRIPTION
Refreshed a bit the ledger doc landing page that was still referring to agent land network.
Fixed broken link on network page
Updated readme to remove unnecessary libc notes.