### PR TITLE
feat: Pruning - expose cli command

### DIFF
--- a/cmd/fetchd/cmd/root.go
+++ b/cmd/fetchd/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"errors"
+	"github.com/cosmos/cosmos-sdk/client/pruning"
 	"io"
 	"math/big"
 	"os"
@@ -145,6 +146,7 @@ func initRootCmd(rootCmd *cobra.Command, encodingConfig params.EncodingConfig) {
 		queryCommand(),
 		txCommand(),
 		keys.Commands(app.DefaultNodeHome),
+		pruning.PruningCmd(a.newApp),
 	)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -133,7 +133,7 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-replace github.com/cosmos/cosmos-sdk => github.com/fetchai/cosmos-sdk v0.18.4
+replace github.com/cosmos/cosmos-sdk => github.com/fetchai/cosmos-sdk v0.18.5-0.20230807121023-1d996e843ba9
 
 replace github.com/confio/ics23/go => github.com/cosmos/cosmos-sdk/ics23/go v0.8.0
 

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/fetchai/cosmos-sdk v0.18.4 h1:P+pkN3IlDGBpjBXDGMe+gYuNYYkXF85YgWe0wFVFZk4=
-github.com/fetchai/cosmos-sdk v0.18.4/go.mod h1:Z5M4TX7PsHNHlF/1XanI2DIpORQ+Q/st7oaeufEjnvU=
+github.com/fetchai/cosmos-sdk v0.18.5-0.20230807121023-1d996e843ba9 h1:uRF8puFVGBb4fYrbfRQYEnZUSFwD0GPFtj8DgQYdmik=
+github.com/fetchai/cosmos-sdk v0.18.5-0.20230807121023-1d996e843ba9/go.mod h1:HQsH0e/ZQ0oTvUI1GOcT86lhfSSJjVXP4TItmiNFf6A=
 github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=


### PR DESCRIPTION
Includes a new additional command `prune` within the `fetch` app
- Allows users to specify which blocks are stored locally on disk
- E.g. `fetchd prune --home './' --app-db-backend 'goleveldb' --pruning 'custom' --pruning-keep-recent 100 --
		pruning-keep-every 10, --pruning-interval 10`