### PR TITLE
feat: Upgrade v0.11.3: NOMX token munic. infl. & creation if required

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -721,6 +721,15 @@ func (app *App) GetSubspace(moduleName string) paramstypes.Subspace {
 func (app *App) RegisterUpgradeHandlers(cfg module.Configurator) {
 	const municipalInflationTargetAddress = "fetch1n8d5466h8he33uedc0vsgtahal0mrz55glre03"
 
+	// NOTE(pb): The `fetchd-v0.10.7` upgrade handler *MUST* be present due to the mainnent, where this is the *LAST*
+	//           executed upgrade. Presence of this handler is enforced by the `x/upgrade/abci.go#L31-L40` (see the
+	// https://github.com/fetchai/cosmos-sdk/blob/09cf7baf4297a30acd8d09d9db7dd97d79ffe008/x/upgrade/abci.go#L31-L40).
+	app.UpgradeKeeper.SetUpgradeHandler("fetchd-v0.10.7", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
+		return app.mm.RunMigrations(ctx, cfg, fromVM)
+	})
+
+	// NOTE(pb): The `v0.11.2` upgrade handler *MUST* be present due to Dorado-1 testnet, where this is the *LAST*
+	//           executed upgrade. Please see the details in the NOTE above.
 	app.UpgradeKeeper.SetUpgradeHandler("v0.11.2", func(ctx sdk.Context, plan upgradetypes.Plan, fromVM module.VersionMap) (module.VersionMap, error) {
 		mobixInfl, err := sdk.NewDecFromStr("0.03")
 		if err != nil {

--- a/app/app.go
+++ b/app/app.go
@@ -653,7 +653,7 @@ func (app *App) InitChainer(ctx sdk.Context, req abci.RequestInitChain) abci.Res
 	return app.mm.InitGenesis(ctx, app.appCodec, genesisState)
 }
 
-// LoadHeight loads a particular t eight
+// LoadHeight loads a particular height
 func (app *App) LoadHeight(height int64) error {
 	return app.LoadVersion(height)
 }
@@ -788,9 +788,10 @@ func (app *App) RegisterUpgradeHandlers(cfg module.Configurator) {
 		}
 
 		minter := app.MintKeeper.GetMinter(ctx)
+		municipalInflation := minttypes.NewMunicipalInflation(municipalInflationTargetAddress, inflation)
 		minter.MunicipalInflation = []*minttypes.MunicipalInflationPair{
-			{Denom: "nanomobx", Inflation: minttypes.NewMunicipalInflation("fetch1n8d5466h8he33uedc0vsgtahal0mrz55glre03", inflation)},
-			{Denom: "nanonomx", Inflation: minttypes.NewMunicipalInflation("fetch1n8d5466h8he33uedc0vsgtahal0mrz55glre03", inflation)},
+			{Denom: "nanomobx", Inflation: municipalInflation},
+			{Denom: nomxDenom, Inflation: municipalInflation},
 		}
 
 		app.MintKeeper.SetMinter(ctx, minter)

--- a/go.mod
+++ b/go.mod
@@ -133,7 +133,7 @@ replace google.golang.org/grpc => google.golang.org/grpc v1.33.2
 
 replace github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
-replace github.com/cosmos/cosmos-sdk => github.com/fetchai/cosmos-sdk v0.19.3-0.20231027022256-09cf7baf4297
+replace github.com/cosmos/cosmos-sdk => github.com/fetchai/cosmos-sdk v0.19.3
 
 // This is to add support for Ledger Nano S-Plus on linux + new macOS
 // usb bus device enumeration (it needs to be reiterated here, even though

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/felixge/httpsnoop v1.0.1 h1:lvB5Jl89CsZtGIWuTcDM1E/vkVs49/Ml7JJe07l8SPQ=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
-github.com/fetchai/cosmos-sdk v0.19.3-0.20231027022256-09cf7baf4297 h1:aifpDotvRF/5/Zn/nvMeDlTPh0pa3qRMUwGY6cGqHgU=
-github.com/fetchai/cosmos-sdk v0.19.3-0.20231027022256-09cf7baf4297/go.mod h1:xLNanYMukOhNMWoGJyy6mIZQR+Sf2sIi2Mlq0BY5rCg=
+github.com/fetchai/cosmos-sdk v0.19.3 h1:9cTSRmLRl8g7AbEf3CBT/bT/NhC1VbKcgRu8e0CxU5o=
+github.com/fetchai/cosmos-sdk v0.19.3/go.mod h1:xLNanYMukOhNMWoGJyy6mIZQR+Sf2sIi2Mlq0BY5rCg=
 github.com/fjl/memsize v0.0.0-20180418122429-ca190fb6ffbc/go.mod h1:VvhXpOYNQvB+uIk2RvXzuaQtkQJzzIx6lSBe1xv7hi0=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=


### PR DESCRIPTION
Primary feature of this upgrade is adding municipal inflation configuration for NOMX token

If NOMX token does not exists yet (as it is on Dorado testnet at the moment), or it has zero supply, then NOMX token will be created by minting `10^18 [nanonomx]` supply and denom metadata will be set - everything with the exact same values as NOMX token has on the mainnet.   
