### PR TITLE
fix: CUDOS delegations movement fix

### DIFF
--- a/app/ordered_map.go
+++ b/app/ordered_map.go
@@ -112,28 +112,23 @@ func (om *OrderedMap[K, V]) Has(key K) bool {
 func (om *OrderedMap[K, V]) Delete(key K) {
 	if _, exists := om.values[key]; exists {
 		delete(om.values, key)
-		// Remove key from slice
-		for i, k := range om.keys {
-			if k == key {
-				om.keys = append(om.keys[:i], om.keys[i+1:]...)
-				break
+		// Create a new slice to avoid modifying the original reference
+		newKeys := make([]K, 0, len(om.keys)-1)
+
+		// Remove the key from the keys slice
+		for _, k := range om.keys {
+			if k != key {
+				newKeys = append(newKeys, k)
 			}
 		}
+
+		om.keys = newKeys // Assign the newly created slice to om.keys
 	}
 }
 
 // Keys returns the keys in insertion order
 func (om *OrderedMap[K, V]) Keys() []K {
 	return om.keys
-}
-
-func (om *OrderedMap[K, V]) SafeKeys() []K {
-	// Create a new slice with the same length
-	clonedSlice := make([]K, len(om.keys))
-
-	// Copy the elements
-	copy(clonedSlice, om.keys)
-	return clonedSlice
 }
 
 // PrintOrdered prints the map in current order

--- a/app/ordered_map.go
+++ b/app/ordered_map.go
@@ -127,6 +127,15 @@ func (om *OrderedMap[K, V]) Keys() []K {
 	return om.keys
 }
 
+func (om *OrderedMap[K, V]) SafeKeys() []K {
+	// Create a new slice with the same length
+	clonedSlice := make([]K, len(om.keys))
+
+	// Copy the elements
+	copy(clonedSlice, om.keys)
+	return clonedSlice
+}
+
 // PrintOrdered prints the map in current order
 func (om *OrderedMap[K, V]) PrintOrdered() {
 	for _, key := range om.keys {

--- a/app/upgrade_cudos.go
+++ b/app/upgrade_cudos.go
@@ -2032,9 +2032,11 @@ func DoGenesisAccountMovements(genesisData *GenesisData, cudosCfg *CudosMergeCon
 
 		// Handle delegations movement
 		remainingAmountToMove := sdk.NewIntFromBigInt(accountMovement.Amount.BigInt())
+
 		if sourceDelegations, exists := genesisData.Delegations.Get(accountMovement.SourceAddress); exists {
-			for i := range sourceDelegations.Iterate() {
-				validatorAddr, delegatedAmount := i.Key, i.Value
+			// We iterate and delete from source array at the same time
+			for _, validatorAddr := range sourceDelegations.SafeKeys() {
+				delegatedAmount := sourceDelegations.MustGet(validatorAddr)
 
 				if delegatedAmount.GTE(remainingAmountToMove) {
 					// Split delegation

--- a/app/upgrade_cudos.go
+++ b/app/upgrade_cudos.go
@@ -2035,7 +2035,7 @@ func DoGenesisAccountMovements(genesisData *GenesisData, cudosCfg *CudosMergeCon
 
 		if sourceDelegations, exists := genesisData.Delegations.Get(accountMovement.SourceAddress); exists {
 			// We iterate and delete from source array at the same time
-			for _, validatorAddr := range sourceDelegations.SafeKeys() {
+			for _, validatorAddr := range sourceDelegations.Keys() {
 				delegatedAmount := sourceDelegations.MustGet(validatorAddr)
 
 				if delegatedAmount.GTE(remainingAmountToMove) {


### PR DESCRIPTION
## Proposed Changes
When you iterate over `OrderedMap.Keys()` and during iteration call `Delete` the original reference of keys gets corrupted due to in-place append in `Delete`

I've made `Delete` not to modify the original data so now it is safe to do.


_[describe the changes here...]_

## Linked Issues

_[if applicable, add links to issues resolved by this PR]_

## Types of changes

_What type of change does this pull request make (put an `x` in the boxes that apply)?_

- [ ] Bug fix (non-breaking change that fixes an issue).
- [ ] New feature added (non-breaking change that adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to stop working as expected).
- [ ] Documentation update.
- [ ] Something else (e.g., tests, scripts, example, deployment, infrastructure).

## Checklist

_Put an `x` in the boxes that apply:_

- [ ] I have read the [CONTRIBUTING](https://github.com/fetchai/fetchd/blob/main/CONTRIBUTING.md) guide
- [ ] Checks and tests pass locally

### If applicable

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked that code coverage does not decrease
- [ ] I have added/updated the documentation

## Further comments

_[if this is a relatively large or complex change, kick off a discussion by explaining why you chose the solution you did, what alternatives you considered, etc...]_
