### PR TITLE
docs: add RPC latency benchmark to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,4 @@ The easiest way to get started with a simple network is to run the [docker-compo
 3. [Discord Server](https://discord.gg/fetchai)
 4. [Blog](https://fetch.ai/blog)
 5. [Community Telegram Group](https://t.me/fetch_ai)
+6. [RPC Latency Benchmark](https://openchainbench.com/benchmarks/fetchhub-rpc) — independent p50/p90/p99 monitoring of public FetchHub-4 RPC endpoints from 3 global regions


### PR DESCRIPTION
Adds an independent RPC latency benchmark link to the Resources section.

The benchmark continuously monitors public FetchHub-4 RPC endpoints, reporting p50/p90/p99 latency and availability from 3 global regions over 24h windows — useful for developers choosing a reliable endpoint.

No code changes, documentation only.